### PR TITLE
fix getCodeString return bug

### DIFF
--- a/src/security.vue
+++ b/src/security.vue
@@ -172,10 +172,8 @@
 				event.target.select()
 			},
 			getCodeString () {
-				this.$emit(
-					'input',
-					this.isArray ? this.securityCode : this.securityCode.join('')
-				)
+				let code = this.isArray ? this.securityCode : this.securityCode.join('')
+				this.$emit('input', code)
 
 				return code;
 			}


### PR DESCRIPTION
`return code` in getCodeString method causes an error because code is undefined. This patch fixed that.